### PR TITLE
Fix Uint8Array initialization in swapBytes

### DIFF
--- a/bon.js
+++ b/bon.js
@@ -98,7 +98,7 @@ function checkEndianess() {
 }
 
 function swapBytes(buf, size) {
-    var bytes = Uint8Array(buf);
+    var bytes = new Uint8Array(buf);
     var len = bytes.length;
     if (size == 'WORD') {
         var holder;


### PR DESCRIPTION
## Summary
- construct a Uint8Array with `new` inside `swapBytes` to avoid runtime constructor errors

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68f0ef31a4f4832487350277f8d19953